### PR TITLE
[NEW] add --jsonpath implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,11 @@ A [Nagios]/[Icinga] plugin for checking connectivity to an [MQTT] broker. Or wit
 
 This plugin connects to the specified broker and subscribes to a topic. Upon successful subscription, a message is published to said topic, and the plugin expects to receive that payload within `max_wait` seconds.
 
+## Prerequisite
+This module needs jsonpath-rw. To install, use pip:
+
+ $ pip install jsonpath-rw
+
 ## Configuration
 
 Configuration can be done via the following command line arguments:
@@ -44,9 +49,12 @@ optional arguments:
   -v <value>, --value <value>
                         value to compare against payload received on -s <topic> (defaults to 'PiNG'). If it begins with !,
                         output of the command will be used
+  -j <path>, --jsonpath <path>
+                        if given, the value is interpreted as a JSON string and the value is extracted using the <path>
   -o <operator>, --operator <operator>
-                        operator to compare received value with value. Coose from 'equal' (default), 'lessthan',
-                        and 'greaterthan'. 'equal' compares Strings, the other two convert the arguments to int
+                        operator to compare received value with value. Choose 'eq','equal' (default), 'lt','lessthan',
+                        'gt','greaterthan' or 'ct','contain'.
+                        'equal' compares strings, the other two convert the argument to float before compare
 ```
 
 `max_wait` is the time we're willing to wait for a SUB to the topic we PUBlish on. If we don't receive the MQTT PUB within this many seconds we exist with _CRITICAL_.
@@ -73,6 +81,14 @@ OK - message from devices/mydevice/lastevent at localhost in 0.05s | response_ti
 ./check-mqtt.py -H localhost -t nagios/ListenForPing -s nagios/PublishPongTo -l ping -v pong
 
 OK - message from nagios/PublishPongTo at localhost in 0.05s | response_time=0.05 value=pong
+```
+
+## Jsonpath check example
+
+```
+./check-mqtt.py -H localhost -t devices/mydevice/sensor -v '950' -j '$.BME280.Pressure'-r -o greaterthan
+
+OK - message from devices/mydevice/sensor at localhost in 0.06s | response_time=0.06 value=1005.0
 ```
 
 ## Nagios Configuration

--- a/check-mqtt.py
+++ b/check-mqtt.py
@@ -28,6 +28,8 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 import paho.mqtt.client as paho
+from jsonpath_rw import jsonpath, parse
+import json
 import ssl
 import time
 import sys
@@ -73,21 +75,33 @@ def on_message(mosq, userdata, msg):
     global message
     global status
 
+    payload = msg.payload
+
+    if args.mqtt_jsonpath is not None:
+        try:
+            jspayload = json.loads(payload)
+            jspath = parse(args.mqtt_jsonpath)
+            extractpayload = [match.value for match in jspath.find(jspayload)]
+            payload = extractpayload[0]
+        except:
+            payload = ''
+            pass
+
     elapsed = (time.time() - userdata['start_time'])
     userdata['have_response'] = True
     status = 2
     if args.short_output == True:
-        message = "value=%s | response_time=%.2f value=%s" % (str(msg.payload), elapsed, str(msg.payload))
+        message = "value=%s | response_time=%.2f value=%s" % (str(payload), elapsed, str(payload))
     else:
-        message = "message from %s at %s in %.2fs | response_time=%.2f value=%s" % (args.check_subscription, args.mqtt_host, elapsed, elapsed, str(msg.payload))
+        message = "message from %s at %s in %.2fs | response_time=%.2f value=%s" % (args.check_subscription, args.mqtt_host, elapsed, elapsed, str(payload))
 
-    if args.mqtt_operator == 'lessthan' and float(msg.payload) < float(args.mqtt_value):
+    if (args.mqtt_operator == 'lt' or args.mqtt_operator == 'lessthan') and float(payload) < float(args.mqtt_value):
         status = 0
-    if args.mqtt_operator == 'greaterthan' and float(msg.payload) > float(args.mqtt_value):
+    if (args.mqtt_operator == 'gt' or args.mqtt_operator == 'greaterthan') and float(payload) > float(args.mqtt_value):
         status = 0
-    if args.mqtt_operator == 'equal' and str(msg.payload) == args.mqtt_value:
+    if (args.mqtt_operator == 'eq' or args.mqtt_operator == 'equal') and str(payload) == args.mqtt_value:
         status = 0
-    if args.mqtt_operator == 'contains' and str(msg.payload).find(args.mqtt_value) != -1:
+    if (args.mqtt_operator == 'ct' or args.mqtt_operator == 'contains') and str(payload).find(args.mqtt_value) != -1:
         status = 0
 
         
@@ -125,7 +139,8 @@ parser.add_argument('-s', '--subscription', metavar="<subscription>", help="topi
 parser.add_argument('-r', '--readonly', help="just read the value of the topic", dest='mqtt_readonly', default=False, action='store_true')
 parser.add_argument('-l', '--payload', metavar="<payload>", help="payload which will be PUBLISHed (defaults to 'PiNG'). If it begins with !, output of the command will be used", dest='mqtt_payload', default='PiNG')
 parser.add_argument('-v', '--value', metavar="<value>", help="value to compare against received payload (defaults to 'PiNG'). If it begins with !, output of the command will be used", dest='mqtt_value', default='PiNG')
-parser.add_argument('-o', '--operator', metavar="<operator>", help="operator to compare received value with value. Coose from 'equal' (default), 'lessthan', 'greaterthan' and 'contains'. 'equal' compares Strings, the other two convert the arguments to int", dest='mqtt_operator', default='equal', choices=['equal','lessthan','greaterthan','contains'])
+parser.add_argument('-j', '--jsonpath', metavar="<jsonpath>", help="if given, the value is interpreted as a JSON string and the value is extracted using the jsonpath", dest='mqtt_jsonpath', default=None)
+parser.add_argument('-o', '--operator', metavar="<operator>", help="operator to compare received value with value. Choose from 'eq' or 'equal' (default), 'lt' or 'lessthan', 'gt' or 'greaterthan' and 'ct' or 'contains'. 'eq' compares Strings, the other two convert the arguments to float", dest='mqtt_operator', default='equal', choices=['eq','equal','lt','lessthan','gt','greaterthan','ct','contains'])
 parser.add_argument('-S', '--short', help="use a shorter string on output", dest='short_output', default=False, action='store_true')
 
 args = parser.parse_args()
@@ -196,4 +211,3 @@ while userdata['have_response'] == False and rc == 0:
 mqttc.disconnect()
 
 exitus(status, message)
-


### PR DESCRIPTION
**[NEW] add --jsonpath implementation**: 
Interpretation of the payload as a JSON string and extract value using Jsonpath, e. g.

Payload is `{"Foo":{"Bar":"Test}}`

and the new parameter `--jsonpath '$.Foo.Bar'` is given it first extract` "Test"` as payload and then using the compare functionality.

see [Jsonpath evaluator](http://jsonpath.com/) for more info

**[CHANGE] add --operator common compare shortcuts 'eq','gt','lt' and 'ct'**
some shortcuts for `--operator` parameter added (more common like on bash or perl)

