### PR TITLE
[FIX] keep paho-mqtt 1.6.1 as dependency before migration of script t…

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ A [Nagios]/[Icinga] plugin for checking connectivity to an [MQTT] broker. Or wit
 This plugin connects to the specified broker and subscribes to a topic. Upon successful subscription, a message is published to said topic, and the plugin expects to receive that payload within `max_wait` seconds.
 
 ## Prerequisite
+This module uses the [paho-mqtt] package. Currently it is not compatible to the latest version of the package (paho-mqtt 2.0.0). Please use `pip install paho-mqtt<2`, or use a virtual environment.
+
 This module can use jsonpath-rw. To install, use `$ pip install jsonpath-rw`
 
 ## Configuration
@@ -320,3 +322,4 @@ apply Service "lastevent-health" {
  [nagios]: http://nagios.org
  [icinga]: http://icinga.org
  [mqtt]: http://mqtt.org
+ [paho-mqtt]: https://pypi.org/project/paho-mqtt

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-paho-mqtt
+paho-mqtt<2
 #jsonpath-rw


### PR DESCRIPTION
There are BREAKING changes in paho-mqtt 2.0 (via @[jpmens@mastodon.social](mailto:jpmens@mastodon.social)):

paho.mqtt version 2.0.0 released
https://pypi.org/project/paho-mqtt/

Thanks to [@teixi](https://mastodon.social/@teixi) for a link to the changelog: https://eclipse.dev/paho/files/paho.mqtt.python/html/changelog.html

and most importantly, to Migrations https://eclipse.dev/paho/files/paho.mqtt.python/html/migrations.html